### PR TITLE
Fix memory leaks and performance improvements

### DIFF
--- a/include/dbscan/algo.h
+++ b/include/dbscan/algo.h
@@ -85,7 +85,14 @@ int DBSCAN(intT n, floatT* PF, double epsilon, intT minPts, bool* coreFlagOut, i
 
   typedef kdTree<dim, pointT> treeT;
   auto trees = newA(treeT*, G->numCell());
-  parallel_for(0, G->numCell(), [&](intT i) {trees[i] = NULL;});
+
+  parallel_for(0, G->numCell(), [&](intT i) {
+    if (ccFlag[i]) {
+        trees[i] = new treeT(G->getCell(i)->getItem(), G->getCell(i)->size(), false);
+    } else {
+        trees[i] = NULL;
+    }
+});
 
   // auto degCmp = [&](intT i, intT j) {
   //                 return G->getCell(i)->size() < G->getCell(j)->size();

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setuptools.setup(
         depends=depends,
         py_limited_api=True,
         define_macros=[
-            ('Py_LIMITED_API', '0x03020000'),
             ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
             # ('DBSCAN_VERSION', json.dumps(version)),
         ]

--- a/src/dbscanmodule.cpp
+++ b/src/dbscanmodule.cpp
@@ -71,8 +71,12 @@ static PyObject* DBSCAN_py(PyObject* self, PyObject* args, PyObject *kwargs)
     );
 
     parlay::internal::stop_scheduler();
-
-    return PyTuple_Pack(2, labels, core_samples);
+    
+    PyObject* result_tuple = PyTuple_Pack(2, labels, core_samples);
+    Py_DECREF(X);
+    Py_DECREF(core_samples);
+    Py_DECREF(labels);
+    return result_tuple;
 }
 
 PyDoc_STRVAR(doc_DBSCAN,


### PR DESCRIPTION
**Fixes**
1. Major leak: `hasEdge` duplicates some `new treeT` objects without removing them. Fix - preallocate them. Note - I had trouble using locks here. 
    * Performance improvement: 1.16x; 
    * Memory improvement: from ~6.3 GB that accumulated during my test to ~550 MB;

2. Major leak: Not using `Py_DECREF`. 
    * Performance: Negligible;
    * Memory improvement: from ~550 MB that accumulated during my test, a few MB;

3. Minor leak: Multiple threads cache the same data in `rangeNeighbor` at once, overwriting each other. Fix - the use of Locks. 
    * Performance: Negligible; 
    * Memory improvement: from a few MB (that would cause problems over long-term use) to no leakage;

4. Performance optimization: The Scheduler gets initialized every `DBSCAN` call. Fix: call it once. 
    * Performance improvement: 1.48x on top of the first one;
    * Memory improvement: None;

For performance and memory testing, I used a point cloud of shape (12895, 2) with unique labels: [-1  0  1  2  3  4  5  6] in an n=2000 for loop.
A final test of n=60000 proved no increase in memory by Heaptrack. Total performance gain 1.72x.