### PR TITLE
fix unintended dereference (seg fault)

### DIFF
--- a/include/dbscan/pbbs/ndHash.h
+++ b/include/dbscan/pbbs/ndHash.h
@@ -82,16 +82,17 @@ class Table {
       }
 */
 
- Table(intT size, HASH hashF) :
+  Table(intT size, HASH hashF) :
     m((intT)1 << utils::log2Up(100+(intT)(2.0*(float)size))),
     mask(m-1),
-    empty(hashF.empty()),
     hashStruct(hashF),
     TA(newA(eType,m)),
     compactL(NULL),
 	  load(2.0)
-      { clearA(TA,m,empty);
-      }
+    {
+      empty = hashStruct.empty();
+      clearA(TA,m,empty);
+    }
 
 /*
   // Constructor that takes an array for the hash table space.  The


### PR DESCRIPTION
This fixes a rare segmentation fault. 

What was happening:
grid.h `table = new tableT(cellMax*2, cellHash<dim, objT>(myHash));` passes a temporary `cellHash`.

original code:
```c++
 Table(intT size, HASH hashF) :  
    m((intT)1 << utils::log2Up(100+(intT)(2.0*(float)size))),
    mask(m-1),
    empty(hashF.empty()),  
    hashStruct(hashF),
    TA(newA(eType,m)),
    compactL(NULL),
	  load(2.0)
      { clearA(TA,m,empty);
      }
```
Problem: `hashF` is the temporary, `empty()` returns pointer to `cell`, which is a part of the tmp. The tmp `cell` gets deleted after the `Table` initialization list finishes. `hashF` (tmp) gets copied to `hashStruct` via copy constructor, but `empty(hashF.empty())` ends up dereferenced. 
Fix: Initialize empty from the copy of  `hashF`  (`hashStruct`). This only works after the initialization list has finished.
