### PR TITLE
Add optional sequential mode for efficiency

### DIFF
--- a/include/dbscan/pbbs/parallel.h
+++ b/include/dbscan/pbbs/parallel.h
@@ -180,6 +180,15 @@ static void printScheduler() {
 
 #else
 
+// Fix errors:
+#include <atomic>
+namespace parlay {
+  namespace internal {
+    extern inline void start_scheduler() {}
+    extern inline void stop_scheduler() {}
+  }
+}
+
 #define cilk_spawn
 #define cilk_sync
 #define parallel_main main

--- a/include/dbscan/pbbs/parallel.h
+++ b/include/dbscan/pbbs/parallel.h
@@ -139,26 +139,38 @@ namespace parlay {
       get_default_scheduler().stop();
     }
   }
+  inline bool sequential = false;
 
   inline size_t num_workers() {
-    return internal::get_default_scheduler().num_workers();
+    return sequential ? 1u : internal::get_default_scheduler().num_workers();
   }
 
   inline size_t worker_id() {
-    return internal::get_default_scheduler().worker_id();
+    return sequential ? 0u : internal::get_default_scheduler().worker_id();
   }
 
   template <class F>
   inline void parallel_for(size_t start, size_t end, F f,
 			   size_t granularity=0,
 			   bool conservative=false) {
-    if (end > start)
-      internal::get_default_scheduler().parfor(start, end, f, granularity, conservative);
+    if (end > start){
+      if (sequential){
+        for(size_t i=start; i<end; ++i) f(i);
+      }
+      else{
+        internal::get_default_scheduler().parfor(start, end, f, granularity, conservative);
+      }
+    }
   }
 
   template <typename Lf, typename Rf>
   inline void par_do(Lf left, Rf right, bool conservative=false) {
-    return internal::get_default_scheduler().pardo(left, right, conservative);
+    if (sequential) {
+      left(); right();
+    }
+    else {
+      internal::get_default_scheduler().pardo(left, right, conservative);
+    }
   }
 }
 
@@ -171,8 +183,8 @@ using namespace parlay;
 #define par_for_1 for
 #define par_for_256 for
 
-static int getWorkers() {return (int)num_workers();}
-static int getWorkerId() {return (int)worker_id();}
+static int getWorkers() {return sequential ? 1 : (int)num_workers();}
+static int getWorkerId() {return sequential ? 0 : (int)worker_id();}
 static void setWorkers(int n) { }
 static void printScheduler() {
   cout << "scheduler = Parlay-HomeGrown" << endl;


### PR DESCRIPTION
Can I add an option to set sequential mode? 
Sequential can be more efficient because it does not have the scheduler's overhead, but it depends on the dataset. Here are the results from my testing:

```text
PARLAY_NUM_THREADS: Not set
  ordered point cloud:
     New threaded:   1.23 ms; CPU: ~650%;
     New sequential: 1.23 ms; CPU:  100%; efficiency: 6.5x
     Original:       1.23 ms; CPU: ~650%; 
  shuffled point cloud:
     New threaded:   1.46 ms; CPU: ~650%
     New sequential: 2.31 ms; CPU:  100%; efficiency: 4.1x
     Original:       1.45 ms; CPU: ~650%
     
PARLAY_NUM_THREADS: 1
  ordered point cloud:
     New threaded:   2.64 ms; CPU:  100%
     New sequential: 1.23 ms; CPU:  100%; efficiency: 2.1x
     Original:       2.64 ms; CPU:  100%
  shuffled point cloud:
     New threaded:   3.70 ms; CPU:  100%
     New sequential: 2.33 ms; CPU:  100%; efficiency: 1.6x
     Original:       3.69 ms; CPU:  100%
```

Using sequential mode is faster than setting PARLAY_NUM_THREADS to 1.
To make this work, I used a simple if check in the main loop, but the performance cost is within a margin of error - unnoticeable.

Usage:

```python
import dbscan

# set sequential, disable threading
dbscan.set_sequential()
print("sequential:", dbscan.get_sequential())
dbscan.DBSCAN(points, eps=1.5, min_samples=15)

# enable threading again
dbscan.set_sequential(False) 
print("sequential:", dbscan.get_sequential())
dbscan.DBSCAN(points, eps=1.5, min_samples=15)
```